### PR TITLE
Chroma.Collection.add needs to be passed collection_id instead of name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ In your config file you can setup the following:
 config :chroma, 
   host: "http://localhost:8000",
   api_base: "api",
-  api_version: "v1"
+  api_version: "v2"
 ```
 
-By default the config is set to `api/v1`
+By default the config is set to `api/v2`
 
 ## Usage
 

--- a/lib/chroma.ex
+++ b/lib/chroma.ex
@@ -38,7 +38,7 @@ defmodule Chroma do
   def api_version do
     case Application.fetch_env(:chroma, :api_version) do
       {:ok, api_version} -> api_version
-      _ -> "v1"
+      _ -> "v2"
     end
   end
 end

--- a/lib/chroma/collection.ex
+++ b/lib/chroma/collection.ex
@@ -1062,7 +1062,13 @@ defmodule Chroma.Collection do
 
       _ ->
         error_reason =
-          if is_map(body) and Map.has_key?(body, "error"), do: body["error"], else: body
+          cond do
+            is_map(body) and Map.has_key?(body, "error") and Map.has_key?(body, "message") ->
+              "#{body["error"]}: #{body["message"]}"
+
+            is_map(body) and Map.has_key?(body, "error") ->
+              body["error"]
+          end
 
         {:error, error_reason}
     end

--- a/lib/chroma/collection.ex
+++ b/lib/chroma/collection.ex
@@ -68,10 +68,10 @@ defmodule Chroma.Collection do
   """
   @spec query(Chroma.Collection.t(), keyword()) :: {:error, any()} | {:ok, any()}
 
-  def query(%Chroma.Collection{tenant: tenant, database: database, name: name}, kargs)
+  def query(%Chroma.Collection{tenant: tenant, database: database, id: id}, kargs)
       when is_binary(tenant) and tenant != "" and
              is_binary(database) and database != "" and
-             is_binary(name) and name != "" do
+             is_binary(id) and id != "" do
     {n_results, map} =
       kargs
       |> Enum.into(%{})
@@ -87,7 +87,7 @@ defmodule Chroma.Collection do
           |> Map.put(:query_embeddings, query_embeddings)
 
         url =
-          "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{name}/query"
+          "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{id}/query"
 
         url
         |> Req.post(json: json_payload)
@@ -662,12 +662,12 @@ defmodule Chroma.Collection do
   """
   @spec update(Chroma.Collection.t(), map()) :: {:error, any()} | {:ok, any()}
 
-  def update(%Chroma.Collection{tenant: tenant, database: database, name: name}, %{} = data)
+  def update(%Chroma.Collection{tenant: tenant, database: database, id: id}, %{} = data)
       when is_binary(tenant) and tenant != "" and
              is_binary(database) and database != "" and
-             is_binary(name) and name != "" do
+             is_binary(id) and id != "" do
     url =
-      "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{name}/update"
+      "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{id}/update"
 
     url
     |> Req.post(json: data)
@@ -748,12 +748,12 @@ defmodule Chroma.Collection do
   """
   @spec upsert(Chroma.Collection.t(), map()) :: {:error, any()} | {:ok, any()}
 
-  def upsert(%Chroma.Collection{tenant: tenant, database: database, name: name}, %{} = data)
+  def upsert(%Chroma.Collection{tenant: tenant, database: database, id: id}, %{} = data)
       when is_binary(tenant) and tenant != "" and
              is_binary(database) and database != "" and
-             is_binary(name) and name != "" do
+             is_binary(id) and id != "" do
     url =
-      "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{name}/upsert"
+      "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{id}/upsert"
 
     url
     |> Req.post(json: data)
@@ -838,10 +838,10 @@ defmodule Chroma.Collection do
     modify(collection, args)
   end
 
-  def modify(%Chroma.Collection{tenant: tenant, database: database, name: name}, %{} = args)
+  def modify(%Chroma.Collection{tenant: tenant, database: database, id: id}, %{} = args)
       when is_binary(tenant) and tenant != "" and
              is_binary(database) and database != "" and
-             is_binary(name) and name != "" do
+             is_binary(id) and id != "" do
     json =
       %{new_name: args[:new_name], new_metadata: args[:new_metadata]}
       |> Map.filter(fn {_, v} -> v != nil and v != %{} and v != [] end)
@@ -849,7 +849,7 @@ defmodule Chroma.Collection do
     if map_size(json) == 0 do
       {:error, "No valid update fields (:new_name or :new_metadata) provided in the data map."}
     else
-      url = "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{name}"
+      url = "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{id}"
 
       url
       |> Req.put(json: json)
@@ -920,11 +920,11 @@ defmodule Chroma.Collection do
   """
   @spec delete(Chroma.Collection.t()) :: any()
 
-  def delete(%Chroma.Collection{tenant: tenant, database: database, name: name})
+  def delete(%Chroma.Collection{tenant: tenant, database: database, id: id})
       when is_binary(tenant) and tenant != "" and
              is_binary(database) and database != "" and
-             is_binary(name) and name != "" do
-    url = "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{name}"
+             is_binary(id) and id != "" do
+    url = "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{id}"
 
     url
     |> Req.delete()
@@ -987,12 +987,12 @@ defmodule Chroma.Collection do
   """
   @spec count(Chroma.Collection.t()) :: any()
 
-  def count(%Chroma.Collection{tenant: tenant, database: database, name: name})
+  def count(%Chroma.Collection{tenant: tenant, database: database, id: id})
       when is_binary(tenant) and tenant != "" and
              is_binary(database) and database != "" and
-             is_binary(name) and name != "" do
+             is_binary(id) and id != "" do
     url =
-      "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{name}/count"
+      "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{id}/count"
 
     url
     |> Req.get()

--- a/lib/chroma/collection.ex
+++ b/lib/chroma/collection.ex
@@ -920,11 +920,11 @@ defmodule Chroma.Collection do
   """
   @spec delete(Chroma.Collection.t()) :: any()
 
-  def delete(%Chroma.Collection{tenant: tenant, database: database, id: id})
+  def delete(%Chroma.Collection{tenant: tenant, database: database, name: name})
       when is_binary(tenant) and tenant != "" and
              is_binary(database) and database != "" and
-             is_binary(id) and id != "" do
-    url = "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{id}"
+             is_binary(name) and name != "" do
+    url = "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{name}"
 
     url
     |> Req.delete()

--- a/lib/chroma/collection.ex
+++ b/lib/chroma/collection.ex
@@ -580,12 +580,12 @@ defmodule Chroma.Collection do
   """
   @spec add(Chroma.Collection.t(), map()) :: any()
 
-  def add(%Chroma.Collection{tenant: tenant, database: database, name: name}, %{} = data)
+  def add(%Chroma.Collection{tenant: tenant, database: database, id: id}, %{} = data)
       when is_binary(tenant) and tenant != "" and
              is_binary(database) and database != "" and
-             is_binary(name) and name != "" do
+             is_binary(id) and id != "" do
     url =
-      "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{name}/add"
+      "#{Chroma.api_url()}/tenants/#{tenant}/databases/#{database}/collections/#{id}/add"
 
     url
     |> Req.post(json: data)

--- a/lib/chroma/collection.ex
+++ b/lib/chroma/collection.ex
@@ -1068,6 +1068,9 @@ defmodule Chroma.Collection do
 
             is_map(body) and Map.has_key?(body, "error") ->
               body["error"]
+
+            true ->
+              "Unexpected error format: #{inspect(body)}"
           end
 
         {:error, error_reason}


### PR DESCRIPTION
Want to ask a question. It seems my version of Chroma (1.0.0), the Add Data route expects a Collection ID instead of name. 

Is this new? Is that why I"m seeing something different?

![Screenshot from 2025-05-09 17-20-00](https://github.com/user-attachments/assets/47c5cd0d-a889-4839-986a-55852408ce79)
